### PR TITLE
Transform refactor

### DIFF
--- a/src/translator/app.py
+++ b/src/translator/app.py
@@ -79,12 +79,18 @@ def main():
 
             # Run the transformation
             logging.info(f"Running transformation {args.transform}")
+            # build metadata
+            metadata = {
+                "duration" : video_info.get("duration", 0),
+            }
             transformation = TransformationFactory.get_transformation_service(TranscriptionTransformation(args.transform))
-            transformed_transcript = transformation.transform(combined_transcription)
+            transformed_transcript = transformation.transform(combined_transcription, metadata=metadata)
         except Exception as e:
             logging.error(f"An error occurred during transcript adjustment or transformation: {str(e)}")
             print(json.dumps({"error": f"An error occurred: {str(e)}"}))
             raise
+        finally:
+            os.remove(audio_file_path)
 
         result = {
             "url": args.url,
@@ -97,7 +103,7 @@ def main():
             "transform": args.transform
         }
 
-        os.remove(audio_file_path)
+        
 
         print(json.dumps(result))
 

--- a/src/translator/app.py
+++ b/src/translator/app.py
@@ -81,8 +81,10 @@ def main():
             logging.info(f"Running transformation {args.transform}")
             # build metadata
             metadata = {
-                "duration" : video_info.get("duration", 0),
+                "duration" : video_info.get("duration", 0), # used for youtube highlights
+                "length" : 3000, # used for youtube summary
             }
+            logging.info(f"Metadata: {metadata} for transformation {args.transform}")
             transformation = TransformationFactory.get_transformation_service(TranscriptionTransformation(args.transform))
             transformed_transcript = transformation.transform(combined_transcription, metadata=metadata)
         except Exception as e:

--- a/src/translator/services/transformation/formatting.py
+++ b/src/translator/services/transformation/formatting.py
@@ -8,7 +8,7 @@ class FormattingForReadabilityTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-for-readability", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/formatting.py
+++ b/src/translator/services/transformation/formatting.py
@@ -5,10 +5,10 @@ from .transformation_service import TransformationService
 
 class FormattingForReadabilityTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-for-readability", include_model=True)
+        chain = hub.pull("scribe-ai-format-for-readability", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/keywords.py
+++ b/src/translator/services/transformation/keywords.py
@@ -1,14 +1,13 @@
 from openai import OpenAI
-from langsmith import Client
 from langchain import hub
 from .transformation_service import TransformationService
 
 class FormattingForKeywordsTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-for-keywords", include_model=True)
+        chain = hub.pull("scribe-ai-format-for-keywords", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/keywords.py
+++ b/src/translator/services/transformation/keywords.py
@@ -7,7 +7,7 @@ class FormattingForKeywordsTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-for-keywords", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/paragraphs.py
+++ b/src/translator/services/transformation/paragraphs.py
@@ -7,7 +7,7 @@ class FormattingForParagraphsTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-for-paragraphs", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/paragraphs.py
+++ b/src/translator/services/transformation/paragraphs.py
@@ -1,14 +1,13 @@
 from openai import OpenAI
-from langsmith import Client
 from langchain import hub
 from .transformation_service import TransformationService
 
 class FormattingForParagraphsTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-for-paragraphs", include_model=True)
+        chain = hub.pull("scribe-ai-format-for-paragraphs", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/removefillerwords.py
+++ b/src/translator/services/transformation/removefillerwords.py
@@ -5,10 +5,10 @@ from .transformation_service import TransformationService
 
 class FormattingForFillerWordsTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-for-filler-words", include_model=True)
+        chain = hub.pull("scribe-ai-format-for-filler-words", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/removefillerwords.py
+++ b/src/translator/services/transformation/removefillerwords.py
@@ -8,7 +8,7 @@ class FormattingForFillerWordsTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-for-filler-words", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/summarize.py
+++ b/src/translator/services/transformation/summarize.py
@@ -1,14 +1,13 @@
 from openai import OpenAI
-from langsmith import Client
 from langchain import hub
 from .transformation_service import TransformationService
 
 class SummarizeTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-summary", include_model=True)
+        chain = hub.pull("scribe-ai-summary", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/summarize.py
+++ b/src/translator/services/transformation/summarize.py
@@ -7,7 +7,7 @@ class SummarizeTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-summary", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/transformation_service.py
+++ b/src/translator/services/transformation/transformation_service.py
@@ -15,5 +15,5 @@ class TranscriptionTransformation(Enum):
 
 class TransformationService(ABC):
     @abstractmethod
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict = None) -> str:
         pass

--- a/src/translator/services/transformation/youtubehighlights.py
+++ b/src/translator/services/transformation/youtubehighlights.py
@@ -5,10 +5,10 @@ from .transformation_service import TransformationService
 
 class FormattingForYoutubeHighlightsTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-youtube-highlights", include_model=True)
+        chain = hub.pull("scribe-ai-format-youtube-highlights", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/youtubehighlights.py
+++ b/src/translator/services/transformation/youtubehighlights.py
@@ -8,7 +8,21 @@ class FormattingForYoutubeHighlightsTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-youtube-highlights", include_model=True, api_key=self.llmOpsKey)
-        summary = chain.invoke({"transcript": transcript})
+        summary = chain.invoke({"transcript": transcript, "duration": self.format_duration(metadata.get("duration", 0))})
         return summary.content
+    
+    def format_duration(self, seconds: int) -> str:
+        h = seconds // 3600
+        m = (seconds % 3600) // 60
+        s = seconds % 60
+
+        time_string = ':'.join(f'{unit:02}' for unit in (h, m, s))
+
+        if h > 0:
+            return f"{time_string} hours"
+        elif m > 0:
+            return f"{time_string} minutes"
+        else:
+            return f"{time_string} seconds"

--- a/src/translator/services/transformation/youtubesummary.py
+++ b/src/translator/services/transformation/youtubesummary.py
@@ -1,5 +1,4 @@
 from openai import OpenAI
-from langsmith import Client
 from langchain import hub
 from .transformation_service import TransformationService
 

--- a/src/translator/services/transformation/youtubesummary.py
+++ b/src/translator/services/transformation/youtubesummary.py
@@ -5,10 +5,10 @@ from .transformation_service import TransformationService
 
 class FormattingForYoutubeSummaryTransformation(TransformationService):
     def __init__(self, openai_api_key: str, lang_smith_api_key: str):
+        self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
-        self.prompts = Client(api_key=lang_smith_api_key)
         
     def transform(self, transcript: str) -> str:
-        chain = hub.pull("scribe-ai-format-3000char-summary", include_model=True)
+        chain = hub.pull("scribe-ai-format-3000char-summary", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content

--- a/src/translator/services/transformation/youtubesummary.py
+++ b/src/translator/services/transformation/youtubesummary.py
@@ -10,5 +10,5 @@ class FormattingForYoutubeSummaryTransformation(TransformationService):
         
     def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-3000char-summary", include_model=True, api_key=self.llmOpsKey)
-        summary = chain.invoke({"transcript": transcript})
+        summary = chain.invoke({"transcript": transcript, "length": metadata.get("length", 3000)})
         return summary.content

--- a/src/translator/services/transformation/youtubesummary.py
+++ b/src/translator/services/transformation/youtubesummary.py
@@ -8,7 +8,7 @@ class FormattingForYoutubeSummaryTransformation(TransformationService):
         self.llmOpsKey = lang_smith_api_key
         self.client = OpenAI(api_key=openai_api_key)
         
-    def transform(self, transcript: str) -> str:
+    def transform(self, transcript: str, metadata: dict) -> str:
         chain = hub.pull("scribe-ai-format-3000char-summary", include_model=True, api_key=self.llmOpsKey)
         summary = chain.invoke({"transcript": transcript})
         return summary.content


### PR DESCRIPTION
Transforms now take metadata to use in the prompts - it was the simplest way to dial in prompts variability rather then adding in more text to bloat the context. I pass long the transcript duration into the history prompt rather then having it extract that within the prompt, also enriched the example and made summary prompt take a char length. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transformation processes by incorporating metadata handling, allowing for more contextual data processing.
  - Introduced a new method for formatting duration in the YouTube highlights transformation, improving time representation.

- **Bug Fixes**
  - Improved error handling and resource management during the transformation process by ensuring the removal of audio file paths occurs reliably.

- **Documentation**
  - Updated method signatures across multiple transformation classes to accept new metadata parameters, providing clearer API usage. 

- **Refactor**
  - Streamlined API key handling within various transformation classes, enhancing encapsulation and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->